### PR TITLE
fix: Add missing border style option

### DIFF
--- a/src/apply.ts
+++ b/src/apply.ts
@@ -115,6 +115,8 @@ function setBorder(
         return SpreadsheetApp.BorderStyle.SOLID_MEDIUM
       case 'SOLID_THICK':
         return SpreadsheetApp.BorderStyle.SOLID_THICK
+      case 'DOUBLE':
+        return SpreadsheetApp.BorderStyle.DOUBLE
       default:
     }
     return null


### PR DESCRIPTION
The setBorder function was missing the DOUBLE option for the border style.
This commit adds support for the DOUBLE border style.
